### PR TITLE
Create a security group for jumphost

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -49,3 +49,7 @@ data "aws_region" "current" {}
 data "aws_route53_zone" "jumphost_zone" {
   zone_id = var.route53_zone_id
 }
+
+data "aws_subnet" "first" {
+  id = var.subnet_ids[0]
+}

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,9 @@ resource "aws_launch_template" "jumphost" {
     arn = module.jumphost_profile.instance_profile_arn
   }
   user_data = module.jumphost_userdata.userdata
+  vpc_security_group_ids = [
+    aws_security_group.jumphost.id
+  ]
 }
 
 resource "aws_autoscaling_group" "jumphost" {

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,0 +1,26 @@
+resource "aws_security_group" "jumphost" {
+  description = "Jumphost security group. Allow TCP/22 only."
+  name_prefix = "jumphost-"
+  vpc_id      = data.aws_subnet.first.vpc_id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/test_data/test_module/terraform.tfvars
+++ b/test_data/test_module/terraform.tfvars
@@ -1,4 +1,4 @@
 
-region    = "us-east-2"
-role_arn  = "arn:aws:iam::303467602807:role/jumphost-tester"
+region = "us-east-2"
+role_arn = "arn:aws:iam::303467602807:role/jumphost-tester"
 test_zone = "ci-cd.infrahouse.com"


### PR DESCRIPTION
The default security group on a VPC may be too open. The module will
create a dedicated security group with allowed TCP/22 for SSH and ICMP.
