### PR TITLE
Fix ourput role values

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ module "jumphost" {
 
 | Name | Description |
 |------|-------------|
-| <a name="output_jumphost_asg_name"></a> [jumphost\_asg\_name](#output\_jumphost\_asg\_name) | n/a |
+| <a name="output_jumphost_asg_name"></a> [jumphost\_asg\_name](#output\_jumphost\_asg\_name) | Jumphost autoscaling group |
+| <a name="output_jumphost_hostname"></a> [jumphost\_hostname](#output\_jumphost\_hostname) | n/a |
+| <a name="output_jumphost_instance_profile__arn"></a> [jumphost\_instance\_profile\_\_arn](#output\_jumphost\_instance\_profile\_\_arn) | Instance IAM profile ARN. |
+| <a name="output_jumphost_instance_profile_name"></a> [jumphost\_instance\_profile\_name](#output\_jumphost\_instance\_profile\_name) | Instance IAM profile name. |
 | <a name="output_jumphost_role_arn"></a> [jumphost\_role\_arn](#output\_jumphost\_role\_arn) | Instance IAM role ARN. |
 | <a name="output_jumphost_role_name"></a> [jumphost\_role\_name](#output\_jumphost\_role\_name) | Instance IAM role name. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,26 @@
 output "jumphost_role_arn" {
   description = "Instance IAM role ARN."
-  value       = module.jumphost_profile.instance_profile_arn
+  value       = module.jumphost_profile.instance_role_arn
 }
 output "jumphost_role_name" {
   description = "Instance IAM role name."
+  value       = module.jumphost_profile.instance_role_name
+}
+
+output "jumphost_instance_profile__arn" {
+  description = "Instance IAM profile ARN."
+  value       = module.jumphost_profile.instance_profile_arn
+}
+output "jumphost_instance_profile_name" {
+  description = "Instance IAM profile name."
   value       = module.jumphost_profile.instance_profile_name
 }
 
 output "jumphost_asg_name" {
-  value = aws_autoscaling_group.jumphost.name
+  description = "Jumphost autoscaling group"
+  value       = aws_autoscaling_group.jumphost.name
+}
+
+output "jumphost_hostname" {
+  value = "${var.route53_hostname}.${data.aws_route53_zone.jumphost_zone.name}"
 }

--- a/test_data/test_module/terraform.tfvars
+++ b/test_data/test_module/terraform.tfvars
@@ -1,4 +1,4 @@
 
-region = "us-east-2"
-role_arn = "arn:aws:iam::303467602807:role/jumphost-tester"
+region    = "us-east-2"
+role_arn  = "arn:aws:iam::303467602807:role/jumphost-tester"
 test_zone = "ci-cd.infrahouse.com"


### PR DESCRIPTION
The output variables was called role_name but in fact it returned a profile name. Fixed.
In case a user need the profile - those variables are available in addition to role name/ARN.
Export jumphost hostname. Sometimes, it's handy.
