### PR TITLE
Add variable puppet_custom_facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ has the DNS name `jumphost.yourzone.com`.
 
 ```hcl
 module "jumphost" {
-  source            = "infrahouse/jumphost/aws"
-  version           = "~> 1.2"
+  source            = "registry.infrahouse.com/infrahouse/jumphost/aws"
+  version           = "~> 2.4"
   keypair_name      = aws_key_pair.aleks.key_name
   subnet_ids        = module.management.subnet_public_ids
   environment       = var.environment
@@ -131,6 +131,7 @@ module "jumphost" {
 | <a name="input_keypair_name"></a> [keypair\_name](#input\_keypair\_name) | SSH key pair name that will be added to the jumphost instance | `string` | n/a | yes |
 | <a name="input_nlb_subnet_ids"></a> [nlb\_subnet\_ids](#input\_nlb\_subnet\_ids) | List of subnet ids where the NLB will be created | `list(string)` | n/a | yes |
 | <a name="input_packages"></a> [packages](#input\_packages) | List of packages to install when the instances bootstraps. | `list(string)` | `[]` | no |
+| <a name="input_puppet_custom_facts"></a> [puppet\_custom\_facts](#input\_puppet\_custom\_facts) | A map of custom puppet facts | `any` | `{}` | no |
 | <a name="input_puppet_debug_logging"></a> [puppet\_debug\_logging](#input\_puppet\_debug\_logging) | Enable debug logging if true. | `bool` | `false` | no |
 | <a name="input_puppet_environmentpath"></a> [puppet\_environmentpath](#input\_puppet\_environmentpath) | A path for directory environments. | `string` | `"{root_directory}/environments"` | no |
 | <a name="input_puppet_hiera_config_path"></a> [puppet\_hiera\_config\_path](#input\_puppet\_hiera\_config\_path) | Path to hiera configuration file. | `string` | `"{root_directory}/environments/{environment}/hiera.yaml"` | no |

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ module "jumphost_userdata" {
   version                  = "~> 1.12"
   environment              = var.environment
   role                     = "jumphost"
+  custom_facts             = var.puppet_custom_facts
   puppet_debug_logging     = var.puppet_debug_logging
   puppet_environmentpath   = var.puppet_environmentpath
   puppet_hiera_config_path = var.puppet_hiera_config_path

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,12 @@ variable "packages" {
   default     = []
 }
 
+variable "puppet_custom_facts" {
+  description = "A map of custom puppet facts"
+  type        = any
+  default     = {}
+}
+
 variable "puppet_debug_logging" {
   description = "Enable debug logging if true."
   type        = bool


### PR DESCRIPTION
The `puppet_custom_facts` variable defines custom facts for puppet.
It can be a map of string keys:

```
{
	fact1: "value1",
	fact2: "value2",
	fact3: {
		fact4: "value4"
	}
}
```
