### PR TITLE
Use echo service as health check

### DIFF
--- a/nlb.tf
+++ b/nlb.tf
@@ -23,6 +23,10 @@ resource "aws_lb_target_group" "jumphost" {
     enabled = true
     type    = "source_ip"
   }
+  health_check {
+    protocol = "TCP"
+    port     = 7
+  }
 }
 
 resource "aws_lb_listener" "jumphost" {

--- a/security_group.tf
+++ b/security_group.tf
@@ -23,6 +23,21 @@ resource "aws_vpc_security_group_ingress_rule" "ssh" {
   )
 }
 
+resource "aws_vpc_security_group_ingress_rule" "echo" {
+  description       = "Allow NLB healthchecks"
+  security_group_id = aws_security_group.jumphost.id
+  from_port         = 7
+  to_port           = 7
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+  tags = merge(
+    {
+      Name = "Echo access"
+    },
+    local.tags
+  )
+}
+
 resource "aws_vpc_security_group_ingress_rule" "icmp" {
   description       = "Allow all ICMP traffic"
   security_group_id = aws_security_group.jumphost.id
@@ -30,8 +45,9 @@ resource "aws_vpc_security_group_ingress_rule" "icmp" {
   to_port           = -1
   ip_protocol       = "icmp"
   cidr_ipv4         = "0.0.0.0/0"
-  tags = merge({
-    Name = "ICMP traffic"
+  tags = merge(
+    {
+      Name = "ICMP traffic"
     },
     local.tags
   )

--- a/test_data/jumphost/main.tf
+++ b/test_data/jumphost/main.tf
@@ -20,6 +20,7 @@ module "jumphost" {
   route53_hostname         = local.jumphost_hostname
   asg_min_size             = 1
   asg_max_size             = 1
+  instance_type            = "t3a.medium"
   puppet_hiera_config_path = "/opt/infrahouse-puppet-data/environments/${local.environment}/hiera.yaml"
   packages = [
     "infrahouse-puppet-data"


### PR DESCRIPTION
SSH service starts immediately, even before puppet successfully runs.
xinetd starts echo service on TCP port 7. It starts after puppet apply
is put into the cron.
