### PR TITLE
Prepare for 4.x release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.2.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.1.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.1
+current_version = 3.2.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1
+current_version = 3.1.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.github/workflows/terraform-CD.yml
+++ b/.github/workflows/terraform-CD.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       # Prepare Python environment
       - name: Setup Python Environment

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lint:  ## Run code style checks
 
 .PHONY: test
 test:  ## Run tests on the module
-	pytest -xvvs tests/
+	pytest -xvvs tests/test_module.py
 
 .PHONY: test-keep
 test-keep:  ## Run a test and keep resources

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ thereby enhancing the overall reliability and user experience.
 ```hcl
 module "jumphost" {
   source  = "registry.infrahouse.com/infrahouse/jumphost/aws"
-  version = "3.2.0"
+  version = "3.2.1"
 
   subnet_ids        = module.management.subnet_public_ids
   environment       = var.environment

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module "jumphost" {
   extra_policies = {
     (aws_iam_policy.package-publisher.name) : aws_iam_policy.package-publisher.arn
   }
-  gpg_public_key = file("./files/DEB-GPG-KEY-infrahouse-jammy")
+  gpg_public_key = file("./files/DEB-GPG-KEY-infrahouse-noble")
 }
 ```
 
@@ -95,16 +95,16 @@ module "jumphost" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.31 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_jumphost_profile"></a> [jumphost\_profile](#module\_jumphost\_profile) | registry.infrahouse.com/infrahouse/instance-profile/aws | 1.8.1 |
-| <a name="module_jumphost_userdata"></a> [jumphost\_userdata](#module\_jumphost\_userdata) | registry.infrahouse.com/infrahouse/cloud-init/aws | 1.17.0 |
+| <a name="module_jumphost_userdata"></a> [jumphost\_userdata](#module\_jumphost\_userdata) | registry.infrahouse.com/infrahouse/cloud-init/aws | 1.18.0 |
 
 ## Resources
 
@@ -112,8 +112,8 @@ module "jumphost" {
 |------|------|
 | [aws_autoscaling_group.jumphost](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_cloudwatch_metric_alarm.cpu_utilization_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_efs_file_system.home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
-| [aws_efs_mount_target.packages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
+| [aws_efs_file_system.home-enc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
+| [aws_efs_mount_target.home-enc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
 | [aws_iam_policy.required](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_key_pair.deployer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_launch_template.jumphost](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
@@ -141,6 +141,7 @@ module "jumphost" {
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_default_tags.provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_iam_policy_document.required_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_kms_key.efs_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.jumphost_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_subnet.nlb_selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
@@ -154,10 +155,11 @@ module "jumphost" {
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI id for jumphost instances. By default, latest Ubuntu Pro var.ubuntu\_codename. | `string` | `null` | no |
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of EC2 instances in the ASG. By default, the number of subnets plus one | `number` | `null` | no |
 | <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | Minimal number of EC2 instances in the ASG. By default, the number of subnets. | `number` | `null` | no |
+| <a name="input_efs_kms_key_arn"></a> [efs\_kms\_key\_arn](#input\_efs\_kms\_key\_arn) | KMS key ARN to use for EFS encryption. If not specified, AWS will use the default AWS managed key for EFS. | `string` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Passed on as a puppet fact. | `string` | n/a | yes |
-| <a name="input_extra_files"></a> [extra\_files](#input\_extra\_files) | Additional files to create on an instance. | <pre>list(<br/>    object(<br/>      {<br/>    content     = string<br/>    path        = string<br/>    permissions = string<br/>  }<br/>    )<br/>  )</pre> | `[]` | no |
+| <a name="input_extra_files"></a> [extra\_files](#input\_extra\_files) | Additional files to create on an instance. | <pre>list(<br/>    object(<br/>      {<br/>        content     = string<br/>        path        = string<br/>        permissions = string<br/>      }<br/>    )<br/>  )</pre> | `[]` | no |
 | <a name="input_extra_policies"></a> [extra\_policies](#input\_extra\_policies) | A map of additional policy ARNs to attach to the jumphost role. | `map(string)` | `{}` | no |
-| <a name="input_extra_repos"></a> [extra\_repos](#input\_extra\_repos) | Additional APT repositories to configure on an instance. | <pre>map(<br/>    object(<br/>      {<br/>    source = string<br/>    key    = string<br/>  }<br/>    )<br/>  )</pre> | `{}` | no |
+| <a name="input_extra_repos"></a> [extra\_repos](#input\_extra\_repos) | Additional APT repositories to configure on an instance. | <pre>map(<br/>    object(<br/>      {<br/>        source = string<br/>        key    = string<br/>      }<br/>    )<br/>  )</pre> | `{}` | no |
 | <a name="input_instance_role_name"></a> [instance\_role\_name](#input\_instance\_role\_name) | If specified, the instance profile wil have a role with this name. | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 Instance type. | `string` | `"t3a.micro"` | no |
 | <a name="input_keypair_name"></a> [keypair\_name](#input\_keypair\_name) | SSH key pair name that will be added to the jumphost instance. | `string` | `null` | no |
@@ -178,7 +180,7 @@ module "jumphost" {
 | <a name="input_sns_topic_alarm_arn"></a> [sns\_topic\_alarm\_arn](#input\_sns\_topic\_alarm\_arn) | ARN of SNS topic for Cloudwatch alarms on base EC2 instance. | `string` | `null` | no |
 | <a name="input_ssh_host_keys"></a> [ssh\_host\_keys](#input\_ssh\_host\_keys) | List of instance's SSH host keys. | <pre>list(<br/>    object(<br/>      {<br/>        type : string<br/>        private : string<br/>        public : string<br/>      }<br/>    )<br/>  )</pre> | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet ids where the jumphost instances will be created. | `list(string)` | n/a | yes |
-| <a name="input_ubuntu_codename"></a> [ubuntu\_codename](#input\_ubuntu\_codename) | Ubuntu version to use for the jumphost. Ubuntu noble+ are supported | `string` | `"noble"` | no |
+| <a name="input_ubuntu_codename"></a> [ubuntu\_codename](#input\_ubuntu\_codename) | Ubuntu version to use for the jumphost. Only Ubuntu noble is supported ATM. | `string` | `"noble"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ thereby enhancing the overall reliability and user experience.
 ```hcl
 module "jumphost" {
   source  = "registry.infrahouse.com/infrahouse/jumphost/aws"
-  version = "3.0.1"
+  version = "3.1.0"
 
   subnet_ids        = module.management.subnet_public_ids
   environment       = var.environment

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ thereby enhancing the overall reliability and user experience.
 ```hcl
 module "jumphost" {
   source  = "registry.infrahouse.com/infrahouse/jumphost/aws"
-  version = "3.1.1"
+  version = "3.2.0"
 
   subnet_ids        = module.management.subnet_public_ids
   environment       = var.environment

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ thereby enhancing the overall reliability and user experience.
 ```hcl
 module "jumphost" {
   source  = "registry.infrahouse.com/infrahouse/jumphost/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   subnet_ids        = module.management.subnet_public_ids
   environment       = var.environment

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -70,3 +70,7 @@ data "aws_ami" "selected" {
     ]
   }
 }
+
+data "aws_kms_key" "efs_default" {
+  key_id = "alias/aws/elasticfilesystem"
+}

--- a/efs-enc.tf
+++ b/efs-enc.tf
@@ -14,7 +14,7 @@ resource "aws_efs_file_system" "home-enc" {
   )
 }
 
-resource "aws_efs_mount_target" "packages" {
+resource "aws_efs_mount_target" "home-enc" {
   for_each       = toset(var.subnet_ids)
   file_system_id = aws_efs_file_system.home-enc.id
   subnet_id      = each.key

--- a/efs-enc.tf
+++ b/efs-enc.tf
@@ -1,0 +1,27 @@
+resource "aws_efs_file_system" "home-enc" {
+  creation_token = "jumphost-home-encrypted"
+  encrypted      = true
+  kms_key_id     = data.aws_kms_key.efs_default.arn
+  protection {
+    replication_overwrite = "DISABLED"
+  }
+
+  tags = merge(
+    {
+      Name = "jumphost-home-encrypted"
+    },
+    local.default_module_tags
+  )
+}
+
+resource "aws_efs_mount_target" "packages" {
+  for_each       = toset(var.subnet_ids)
+  file_system_id = aws_efs_file_system.home-enc.id
+  subnet_id      = each.key
+  security_groups = [
+    aws_security_group.efs.id
+  ]
+  lifecycle {
+    create_before_destroy = false
+  }
+}

--- a/efs-enc.tf
+++ b/efs-enc.tf
@@ -1,7 +1,7 @@
 resource "aws_efs_file_system" "home-enc" {
   creation_token = "jumphost-home-encrypted"
   encrypted      = true
-  kms_key_id     = data.aws_kms_key.efs_default.arn
+  kms_key_id     = var.efs_kms_key_arn != null ? var.efs_kms_key_arn : data.aws_kms_key.efs_default.arn
   protection {
     replication_overwrite = "DISABLED"
   }

--- a/efs-replication.tf
+++ b/efs-replication.tf
@@ -1,7 +1,7 @@
-resource "aws_efs_replication_configuration" "home" {
-  source_file_system_id = aws_efs_file_system.home.id
-  destination {
-    region         = data.aws_region.current.name
-    file_system_id = aws_efs_file_system.home-enc.id
-  }
-}
+# resource "aws_efs_replication_configuration" "home" {
+#   source_file_system_id = aws_efs_file_system.home.id
+#   destination {
+#     region         = data.aws_region.current.name
+#     file_system_id = aws_efs_file_system.home-enc.id
+#   }
+# }

--- a/efs-replication.tf
+++ b/efs-replication.tf
@@ -1,0 +1,7 @@
+resource "aws_efs_replication_configuration" "home" {
+  source_file_system_id = aws_efs_file_system.home.id
+  destination {
+    region         = data.aws_region.current.name
+    file_system_id = aws_efs_file_system.home-enc.id
+  }
+}

--- a/efs-replication.tf
+++ b/efs-replication.tf
@@ -1,7 +1,0 @@
-# resource "aws_efs_replication_configuration" "home" {
-#   source_file_system_id = aws_efs_file_system.home.id
-#   destination {
-#     region         = data.aws_region.current.name
-#     file_system_id = aws_efs_file_system.home-enc.id
-#   }
-# }

--- a/efs.tf
+++ b/efs.tf
@@ -1,24 +1,24 @@
-# resource "aws_efs_file_system" "home" {
-#   creation_token = "jumphost-home"
-#   tags = merge(
-#     {
-#       Name = "jumphost-home"
-#     },
-#     local.default_module_tags
-#   )
-# }
-#
-# resource "aws_efs_mount_target" "packages" {
-#   for_each       = toset(var.subnet_ids)
-#   file_system_id = aws_efs_file_system.home.id
-#   subnet_id      = each.key
-#   security_groups = [
-#     aws_security_group.efs.id
-#   ]
-#   lifecycle {
-#     create_before_destroy = false
-#   }
-# }
+resource "aws_efs_file_system" "home" {
+  creation_token = "jumphost-home"
+  tags = merge(
+    {
+      Name = "jumphost-home"
+    },
+    local.default_module_tags
+  )
+}
+
+resource "aws_efs_mount_target" "packages" {
+  for_each       = toset(var.subnet_ids)
+  file_system_id = aws_efs_file_system.home.id
+  subnet_id      = each.key
+  security_groups = [
+    aws_security_group.efs.id
+  ]
+  lifecycle {
+    create_before_destroy = false
+  }
+}
 
 resource "aws_security_group" "efs" {
   description = "Security group for the EFS volume"

--- a/efs.tf
+++ b/efs.tf
@@ -1,24 +1,24 @@
-resource "aws_efs_file_system" "home" {
-  creation_token = "jumphost-home"
-  tags = merge(
-    {
-      Name = "jumphost-home"
-    },
-    local.default_module_tags
-  )
-}
-
-resource "aws_efs_mount_target" "packages" {
-  for_each       = toset(var.subnet_ids)
-  file_system_id = aws_efs_file_system.home.id
-  subnet_id      = each.key
-  security_groups = [
-    aws_security_group.efs.id
-  ]
-  lifecycle {
-    create_before_destroy = false
-  }
-}
+# resource "aws_efs_file_system" "home" {
+#   creation_token = "jumphost-home"
+#   tags = merge(
+#     {
+#       Name = "jumphost-home"
+#     },
+#     local.default_module_tags
+#   )
+# }
+#
+# resource "aws_efs_mount_target" "packages" {
+#   for_each       = toset(var.subnet_ids)
+#   file_system_id = aws_efs_file_system.home.id
+#   subnet_id      = each.key
+#   security_groups = [
+#     aws_security_group.efs.id
+#   ]
+#   lifecycle {
+#     create_before_destroy = false
+#   }
+# }
 
 resource "aws_security_group" "efs" {
   description = "Security group for the EFS volume"

--- a/efs.tf
+++ b/efs.tf
@@ -1,25 +1,3 @@
-resource "aws_efs_file_system" "home" {
-  creation_token = "jumphost-home"
-  tags = merge(
-    {
-      Name = "jumphost-home"
-    },
-    local.default_module_tags
-  )
-}
-
-resource "aws_efs_mount_target" "packages" {
-  for_each       = toset(var.subnet_ids)
-  file_system_id = aws_efs_file_system.home.id
-  subnet_id      = each.key
-  security_groups = [
-    aws_security_group.efs.id
-  ]
-  lifecycle {
-    create_before_destroy = false
-  }
-}
-
 resource "aws_security_group" "efs" {
   description = "Security group for the EFS volume"
   name_prefix = "jumphost-efs-"

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  module_version = "3.2.0"
+  module_version = "3.2.1"
 
   ami_id       = var.ami_id == null ? data.aws_ami.ubuntu_pro.id : var.ami_id
   vpc_id       = data.aws_subnet.selected[var.subnet_ids[0]].vpc_id

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  module_version = "3.0.1"
+  module_version = "3.1.0"
 
   ami_id       = var.ami_id == null ? data.aws_ami.ubuntu_pro.id : var.ami_id
   vpc_id       = data.aws_subnet.selected[var.subnet_ids[0]].vpc_id

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  module_version = "3.1.0"
+  module_version = "3.1.1"
 
   ami_id       = var.ami_id == null ? data.aws_ami.ubuntu_pro.id : var.ami_id
   vpc_id       = data.aws_subnet.selected[var.subnet_ids[0]].vpc_id

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  module_version = "3.1.1"
+  module_version = "3.2.0"
 
   ami_id       = var.ami_id == null ? data.aws_ami.ubuntu_pro.id : var.ami_id
   vpc_id       = data.aws_subnet.selected[var.subnet_ids[0]].vpc_id

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ module "jumphost_profile" {
 
 module "jumphost_userdata" {
   source                   = "registry.infrahouse.com/infrahouse/cloud-init/aws"
-  version                  = "1.17.0"
+  version                  = "1.18.0"
   environment              = var.environment
   role                     = "jumphost"
   gzip_userdata            = true

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ module "jumphost_userdata" {
   mounts = [
     # See https://docs.aws.amazon.com/efs/latest/ug/nfs-automount-efs.html
     [
-      "${aws_efs_file_system.home.dns_name}:/",
+      "${aws_efs_file_system.home-enc.dns_name}:/",
       "/home",
       "nfs4",
       "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev",

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "keypair_name" {
   default     = null
 }
 
+variable "efs_kms_key_arn" {
+  description = "KMS key ARN to use for EFS encryption. If not specified, AWS will use the default AWS managed key for EFS."
+  type        = string
+  default     = null
+}
+
 variable "environment" {
   description = "Environment name. Passed on as a puppet fact."
   type        = string
@@ -173,7 +179,7 @@ variable "subnet_ids" {
 }
 
 variable "ubuntu_codename" {
-  description = "Ubuntu version to use for the jumphost. Ubuntu noble+ are supported"
+  description = "Ubuntu version to use for the jumphost. Only Ubuntu noble is supported ATM."
   type        = string
   default     = "noble"
 }


### PR DESCRIPTION
- **Create encrypted volume and setup replication**
- **Bump version: 3.0.1 → 3.1.0**
- **fix duplicate aws_efs_mount_target packages**
- **Bump version: 3.1.0 → 3.1.1**
- **Use the encrypted volume but keep unecrypted**
- **Bump version: 3.1.1 → 3.2.0**
- **Didn't mean to delete the volume**
- **Bump version: 3.2.0 → 3.2.1**
- **Prepare for 4.x release**
