### PR TITLE
Add configurable EFS creation token to support multiple jumphost instances

### DIFF
--- a/efs-enc.tf
+++ b/efs-enc.tf
@@ -1,5 +1,5 @@
 resource "aws_efs_file_system" "home-enc" {
-  creation_token = "jumphost-home-encrypted"
+  creation_token = var.efs_creation_token
   encrypted      = true
   kms_key_id     = var.efs_kms_key_arn != null ? var.efs_kms_key_arn : data.aws_kms_key.efs_default.arn
   protection {

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "asg_max_size" {
   default     = null
 }
 
+variable "efs_creation_token" {
+  description = "A unique name used as reference when creating the EFS file system. Must be unique across all EFS file systems in the AWS account. Change this value when creating multiple jumphosts to avoid conflicts."
+  type        = string
+  default     = "jumphost-home-encrypted"
+}
+
 variable "extra_files" {
   description = "Additional files to create on an instance."
   type = list(


### PR DESCRIPTION
  Previously, the EFS creation_token was hardcoded to "jumphost-home-encrypted",
  which caused conflicts when deploying multiple jumphost instances in the same
  AWS account. This change introduces the efs_creation_token variable to allow
  users to specify unique tokens for each deployment.

  Changes:
  - Add efs_creation_token variable with type and description
  - Update aws_efs_file_system resource to use var.efs_creation_token
  - Default value maintains backward compatibility with existing deployments
